### PR TITLE
Redone Event class (cleaner + additionnal shock types possible)

### DIFF
--- a/boario/__init__.py
+++ b/boario/__init__.py
@@ -16,6 +16,7 @@
 
 import coloredlogs
 import logging
+from functools import lru_cache
 
 __version__ = "v0.2.0.b"
 
@@ -44,6 +45,12 @@ DEBUGFORMATTER = logging.Formatter(fmt='%(asctime)s [%(levelname)s] - [%(filenam
 """Debug file formatter."""
 
 INFOFORMATTER = logging.Formatter(fmt='%(asctime)s [%(levelname)s] - %(message)s',datefmt='%H:%M:%S',)
+
+
+@lru_cache(10)
+def warn_once(logger, msg: str):
+    logger.warning(msg)
+
 """Log file and stream output formatter."""
 
 #logger.setLevel(logging.DEBUG)

--- a/boario/__init__.py
+++ b/boario/__init__.py
@@ -18,7 +18,7 @@ import coloredlogs
 import logging
 from functools import lru_cache
 
-__version__ = "v0.2.0.b"
+__version__ = "v0.3.0.b"
 
 # Create a logger object.
 logger = logging.getLogger(__name__)

--- a/boario/event.py
+++ b/boario/event.py
@@ -14,116 +14,333 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 from __future__ import annotations
-from typing import Union
-from boario.model_base import ARIOBaseModel
-from boario.extended_models import ARIOModelPsi
+from typing import Optional
+from numpy.typing import ArrayLike
 import warnings
 import numpy as np
+from boario import logger
+import math
 
 __all__ = ['Event']
 
 class Event(object):
-    def __init__(self, event:dict, mrio:Union[ARIOBaseModel,ARIOModelPsi]) -> None:
+    possible_sectors : np.ndarray = None #type: ignore
+    possible_regions : np.ndarray = None #type: ignore
+    temporal_unit_range : int = None #type: ignore
+    z_shape : tuple[int,int] = None #type: ignore
+    y_shape : tuple[int,int] = None #type: ignore
+    x_shape : tuple[int,int] = None #type: ignore
+    regions_idx : np.ndarray = None #type: ignore
+    sectors_idx : np.ndarray = None #type: ignore
+    monetary_unit : int = None #type: ignore
+    sectors_gva_shares : np.ndarray = None #type: ignore
+    Z_distrib: np.ndarray = None #type: ignore
+    mrio_name: str = ""
+
+    def __init__(self, event:dict) -> None:
         super().__init__()
-        self.name = event['name']
-        self.occur = event['occur']
-        self.duration = event['duration']
-        self.q_dmg = event['q_dmg']
-        if 'r_dmg' in event.keys():
-            self.r_dmg = event['r_dmg']
-        self.aff_regions = event['aff_regions']
-        if type(self.aff_regions) is str:
-            self.aff_regions = [self.aff_regions]
-        self.aff_sectors = event['aff_sectors']
-        if type(self.aff_sectors) is str:
-            self.aff_sectors = [self.aff_sectors]
-        self.dmg_distrib_regions = event['dmg_distrib_regions']
-        self.dmg_distrib_sectors_type = event['dmg_distrib_sectors_type']
-        self.dmg_distrib_sectors = event['dmg_distrib_sectors']
-        self.rebuilding_sectors = event['rebuilding_sectors']
-        self.final_demand_rebuild = np.zeros(shape=mrio.Y_0.shape)
-        self.final_demand_rebuild_share = np.zeros(shape=mrio.Y_0.shape)
-        self.industry_rebuild_share = np.zeros(shape=mrio.Z_0.shape)
-        self.industry_rebuild = np.zeros(shape=mrio.Z_0.shape)
-        self.production_share_allocated = np.zeros(shape=mrio.production.shape)
-        self.rebuildable = False
+        if event.get("globals_var") is not None:
+            for k,v in event["globals_var"].items():
+                if Event.__dict__[k] != v:
+                    logger.warning("""You are trying to load an event which was simulated under different global vars, this might break: key:{} with value {} in dict and {} in Event class""".format(k,v,Event.__dict__[k]))
+        for k,v in Event.__dict__.items():
+            if k!="__doc__" and v is None:
+                raise AttributeError("Event Class attribute {} is not set yet so instantiating an Event isn't possible".format(k))
+        self.shock_type = event["shock_type"]
+        self.name = event.get("name","unnamed")
+        self.occurrence = event.get("occur",1)
+        self.duration = event.get("duration",1)
+        self.recovery = event.get("recovery")
+        self.aff_regions = event["aff_regions"] #TODO make it a list if it is a str
+        self.aff_sectors = event["aff_sectors"]
+        self.dmg_regional_distrib = event.get("dmg_regional_distrib",[1/self.aff_regions.size for _ in range(self.aff_regions.size)])
+        self.dmg_sectoral_distrib_type = event.get("dmg_sectoral_distrib_type","equally shared")
+        self.dmg_sectoral_distrib = event.get("dmg_sectoral_distrib",[1/self.aff_sectors.size for _ in range(self.aff_sectors.size)])
+        self.rebuilding_sectors = event["rebuilding_sectors"]
+        self.total_kapital_destroyed = event.get("kapital_damage")
+        self.rebuilding_demand_house = None
+        self.rebuilding_demand_indus = None
+        self.production_share_allocated = None
+        self.prod_cap_delta_arbitrary = None
+        self.happened = False
+        self._rebuildable_kind : bool = False
+        self.rebuild_tau = event.get("rebuild_tau")
+        self.over = False
+        self.init_shock(event)
+        self.event_dict = event
+        self.event_dict["globals_vars"] = {
+            "possible_sectors" : list(self.possible_sectors),
+            "possible_regions" : list(self.possible_regions),
+            "temporal_unit_range" : self.temporal_unit_range,
+            "z_shape" : self.z_shape,
+            "y_shape" : self.y_shape,
+            "x_shape" : self.x_shape,
+            "monetary_unit" : self.monetary_unit,
+            "mrio_used" : self.mrio_name
+            }
+
+
+
+    @property
+    def occurrence(self)->int:
+        return self._occur
+
+    @occurrence.setter
+    def occurrence(self, value:int):
+        if not 0 <= value <= self.temporal_unit_range:
+            raise ValueError("Occurrence of event is not in the range of simulation steps : {} not in [0-{}]".format(value, self.temporal_unit_range))
+        else:
+            self._occur=value
+
+    @property
+    def duration(self)->int:
+        return self._duration
+
+    @duration.setter
+    def duration(self, value:int):
+        if not 0 <= self.occurrence + value <= self.temporal_unit_range:
+            raise ValueError("Occurrence + duration of event is not in the range of simulation steps : {} + {} not in [0-{}]".format(self.occurrence, value, self.temporal_unit_range))
+        else:
+            self._duration=value
+
+    @property
+    def aff_regions(self)->np.ndarray:
+        return self._aff_regions
+
+    @property
+    def aff_regions_idx(self)->np.ndarray:
+        return self._aff_regions_idx
+
+    @aff_regions.setter
+    def aff_regions(self, value:ArrayLike|str):
+        value = np.array(value)
+        impossible_regions = np.setdiff1d(value,self.possible_regions)
+        if impossible_regions.size > 0:
+            raise ValueError("These regions are not in the model : {}".format(impossible_regions))
+        else:
+            self._aff_regions = value
+            self._aff_regions_idx = np.searchsorted(self.possible_regions, value)
+
+    @property
+    def aff_sectors(self)->np.ndarray:
+        return self._aff_sectors
+
+    @property
+    def aff_sectors_idx(self)->np.ndarray:
+        return self._aff_sectors_idx
+
+    @aff_sectors.setter
+    def aff_sectors(self, value):
+        value = np.array(value)
+        impossible_sectors = np.setdiff1d(value,self.possible_sectors)
+        if impossible_sectors.size > 0 :
+            raise ValueError("These sectors are not in the model : {}".format(impossible_sectors))
+        else:
+            self._aff_sectors = value
+            self._aff_sectors_idx = np.searchsorted(self.possible_sectors, value)
+
+    @property
+    def dmg_regional_distrib(self)->np.ndarray:
+        return self._dmg_regional_distrib
+
+    @dmg_regional_distrib.setter
+    def dmg_regional_distrib(self,value:ArrayLike):
+        if self.aff_regions is None:
+            raise AttributeError("Affected regions attribute isn't set yet")
+        value = np.array(value)
+        if value.size != self.aff_regions.size:
+            raise ValueError("There are {} affected regions by the event and length of given damage distribution is {}".format(self.aff_regions.size,value.size))
+        s = value.sum()
+        if not math.isclose(s,1):
+            raise ValueError("Damage distribution doesn't sum up to 1 but to {}, which is not valid".format(s))
+        self._dmg_regional_distrib = value
+
+    @property
+    def dmg_sectoral_distrib(self)->np.ndarray:
+        return self._dmg_sectoral_distrib
+
+    @dmg_sectoral_distrib.setter
+    def dmg_sectoral_distrib(self,value:ArrayLike):
+        if self.aff_sectors is None:
+            raise AttributeError("Affected sectors attribute isn't set yet")
+        value = np.array(value)
+        if value.size != self.aff_sectors.size:
+            raise ValueError("There are {} affected sectors by the event and length of given damage distribution is {}".format(self.aff_sectors.size,value.size))
+        s = value.sum()
+        if not math.isclose(s,1):
+            raise ValueError("Damage distribution doesn't sum up to 1 but to {}, which is not valid".format(s))
+        self._dmg_sectoral_distrib = value
+
+    @property
+    def dmg_sectoral_distrib_type(self)->str:
+        return self._dmg_sectoral_distrib_type
+
+    @dmg_sectoral_distrib_type.setter
+    def dmg_sectoral_distrib_type(self,value:str):
+        self._dmg_sectoral_distrib_type=value
+
+    @property
+    def rebuilding_sectors(self)->Optional[np.ndarray]:
+        return self._rebuilding_sectors
+
+    @property
+    def rebuilding_sectors_idx(self)->Optional[np.ndarray]:
+        return self._rebuilding_sectors_idx
+
+    @property
+    def rebuilding_sectors_shares(self)->Optional[np.ndarray]:
+        return self._rebuilding_sectors_shares
+
+    @rebuilding_sectors.setter
+    def rebuilding_sectors(self, value:dict[str,float]|None):
+        if value is None:
+            self._rebuilding_sectors = None
+            self._rebuilding_sectors_idx = None
+        else:
+            reb_sectors = np.array(list(value.keys()))
+            reb_shares = np.array(list(value.values()))
+            impossible_sectors = np.setdiff1d(reb_sectors,self.possible_sectors)
+            if impossible_sectors.size > 0 :
+                raise ValueError("These sectors are not in the model : {}".format(impossible_sectors))
+            else:
+                self._rebuilding_sectors = reb_sectors
+                self._rebuilding_sectors_idx = np.searchsorted(self.possible_sectors, reb_sectors)
+                self._rebuilding_sectors_shares = reb_shares
+
+    @property
+    def rebuilding_demand_house(self)->Optional[np.ndarray]:
+        return self._rebuilding_demand_house
+
+    @rebuilding_demand_house.setter
+    def rebuilding_demand_house(self,value:ArrayLike|None):
+        if value is None:
+            self._rebuilding_demand_house = None
+        else:
+            value = np.array(value)
+            if value.shape != self.y_shape:
+                raise ValueError("Incorrect shape give for rebuilding_demand_house: {} given and {} expected".format(value.shape, self.y_shape))
+            self._rebuilding_demand_house = value
+
+    @property
+    def rebuilding_demand_indus(self)->Optional[np.ndarray]:
+        return self._rebuilding_demand_indus
+
+    @rebuilding_demand_indus.setter
+    def rebuilding_demand_indus(self,value:ArrayLike|None):
+        if value is None:
+            self._rebuilding_demand_indus = value
+        else:
+            value = np.array(value)
+            if value.shape != self.z_shape:
+                raise ValueError("Incorrect shape give for rebuilding_demand_indus: {} given and {} expected".format(value.shape, self.z_shape))
+            self._rebuilding_demand_indus = value
+
+    @property
+    def rebuildable(self)->Optional[bool]:
+        return self._rebuildable
+
+    @rebuildable.setter
+    def rebuildable(self,current_temporal_unit:int):
+        if self._rebuildable_kind:
+            reb = (self.occurrence + self.duration) <= current_temporal_unit
+            if reb and not self.rebuildable :
+                logger.info("Temporal_Unit : {} ~ Event named {} that occured at {} in {} for {} damages has started rebuilding".format(current_temporal_unit,self.name,self.occurrence, self._aff_regions, self.total_kapital_destroyed))
+            self._rebuildable = reb
+
+    @property
+    def prod_cap_delta_arbitrary(self)->Optional[np.ndarray]:
+        return self._prod_cap_delta_arbitrary
+
+    @prod_cap_delta_arbitrary.setter
+    def prod_cap_delta_arbitrary(self, value:dict[str,float]|None):
+        if value is None:
+            self._prod_cap_delta_arbitrary = None
+        else:
+            if self.aff_regions is None:
+                raise AttributeError("Affected regions attribute isn't set yet")
+            aff_sectors = np.array(list(value.keys()))
+            aff_shares = np.array(list(value.values()))
+            impossible_sectors = np.setdiff1d(aff_sectors,self.possible_sectors)
+            if impossible_sectors.size > 0 :
+                raise ValueError("These sectors are not in the model : {}".format(impossible_sectors))
+            self._aff_sectors = aff_sectors
+            self._aff_sectors_idx = np.searchsorted(self.possible_sectors, aff_sectors)
+            aff_industries_idx = np.array([self.possible_sectors.size * ri + si for ri in self.regions_idx for si in self._aff_sectors_idx])
+            self._prod_cap_delta_arbitrary = np.zeros(shape=self.possible_sectors.size)
+            self._prod_cap_delta_arbitrary[aff_industries_idx] = np.tile(aff_shares,self._aff_regions.size)
+
+    def init_shock(self, event:dict):
+        """Initiate shock from the event. Methods called by __init__.
+
+        Sets the rebuilding demand for households and industry.
+
+        First, if multiple regions are affected, it computes the vector of how damages are distributed across these.
+        Then it computes the vector of how regional damages are distributed across affected sectors.
+        It produces a ``n_regions`` * ``n_sectors`` sized vector hence stores the damage (i.e. capital destroyed) for all industries.
+
+        This method also computes the `rebuilding demand` matrices from households and industries, i.e. the demand addressed to the rebuilding
+        industries consequent to the shock.
+
+        See :ref:`How to define Events <boario-events>` for further detail on how to parameter these distribution.
+
+        Parameters
+        ----------
+        event_to_add_id : int
+            The id (rank it the ``events`` list) of the event to shock the model with.
+
+        Raises
+        ------
+        ValueError
+            Raised if the production share allocated to rebuilding (in either
+            the impacted regions or the others) is not in [0,1].
+        """
+
+        if self.shock_type == "kapital_destroyed_rebuild":
+            self._rebuildable_kind = True
+            if self.total_kapital_destroyed is None:
+                raise AttributeError("Total kapital destroyed isn't set yet, this shouldn't happen.")
+            regions_idx = np.arange(self.possible_regions.size)
+            aff_industries_idx = np.array([self.possible_sectors.size * ri + si for ri in self._aff_regions_idx for si in self._aff_sectors_idx])
+            if not isinstance(self.total_kapital_destroyed, (int,float)):
+                raise ValueError("Kapital damages is {}, which is not valid".format(type(self.total_kapital_destroyed)))
+            self.total_kapital_destroyed /= self.monetary_unit
+            self.remaining_kapital_destroyed = self.total_kapital_destroyed
+            regional_damages = np.array(self.dmg_regional_distrib) * self.total_kapital_destroyed
+            # GDP CASE
+            if self.dmg_sectoral_distrib_type == "gdp":
+                shares = self.sectors_gva_shares.reshape((self.possible_regions.size,self.possible_sectors.size))
+                self.dmg_sectoral_distrib = (shares[self._aff_regions_idx][:,self._aff_sectors_idx]/shares[self._aff_regions_idx][:,self._aff_sectors_idx].sum(axis=1)[:,np.newaxis])
+
+            regional_sectoral_damages = regional_damages * self.dmg_sectoral_distrib
+
+            # REBUILDING
+            if self._rebuilding_sectors_idx is None:
+                raise ValueError("Rebuilding sectors are not set for this event")
+            rebuilding_industries_idx = np.array([self.possible_sectors.size * ri + si for ri in self._aff_regions_idx for si in self._rebuilding_sectors_idx])
+            rebuilding_industries_RoW_idx = np.array([self.possible_sectors.size * ri + si for ri in regions_idx if ri not in self._aff_regions_idx for si in self._rebuilding_sectors_idx])
+            rebuilding_demand = np.outer(self._rebuilding_sectors_shares,regional_sectoral_damages)
+            tmp = np.zeros(self.z_shape,dtype="float")
+            mask = np.ix_(np.union1d(rebuilding_industries_RoW_idx,rebuilding_industries_idx),aff_industries_idx)
+
+            tmp[mask] = self.Z_distrib[mask] * np.tile(rebuilding_demand, (self.possible_regions.size,1))
+            self.rebuilding_demand_indus = tmp
+
+            self.rebuilding_demand_house = np.zeros(shape=self.y_shape)
+            #self.rebuilding_share_house = np.zeros(shape=self.z_shape)
+            #self.rebuildind_share_indus = np.zeros(shape=self.z_shape)
+            #self.production_share_allocated = np.zeros(shape=self.x_shape)
+
+        elif self.shock_type == "production_capacity_loss":
+            self.prod_cap_delta = event["prod_cap_delta"]
 
     def __repr__(self):
         #TODO: find ways to represent long lists
         return f''' [Representation WIP]
         Event(
               name = {self.name},
-              occur = {self.occur},
+              occur = {self.occurrence},
               duration = {self.duration}
-              q_dmg = {self.q_dmg},
               aff_regions = {self.aff_regions},
               aff_sectors = {self.aff_sectors},
-              dmg_distrib_sectors_type = {self.dmg_distrib_sectors_type}
              )
         '''
-
-    def check_values(self, sim) -> None:
-        if self.occur < 0:
-            raise ValueError("Event occurence time is negative, check events json")
-        if self.occur > sim.n_temporal_units_to_sim:
-            raise ValueError("Event occurence time is outside simulation, check events and sim json")
-        if self.q_dmg < 0:
-            raise ValueError("Event damages are negative, check events json")
-        if not set(self.aff_regions).issubset(sim.model.regions):
-            tmp = set(self.aff_regions).difference(set(sim.model.regions))
-            raise ValueError("""A least one affected region is not a valid region in the mrio table, check events json
-
-            suspicious regions : {}
-            """.format(tmp))
-        if not set(self.aff_sectors).issubset(sim.model.sectors):
-            tmp = set(self.aff_sectors).difference(set(sim.model.sectors))
-            raise ValueError("""A least one affected sector is not a valid sector in the mrio table, check events json
-
-            suspicious sectors : {}
-            """.format(tmp))
-        if not set(self.rebuilding_sectors).issubset(sim.model.sectors):
-            tmp = set(self.rebuilding_sectors).difference(set(sim.model.sectors))
-            raise ValueError("""A least one rebuilding sector is not a valid sector in the mrio table, check events json
-
-            suspicious sectors : {}
-            """.format(tmp))
-        if self.duration < 0:
-            raise ValueError("Event duration is negative, check events json")
-        if self.occur+self.duration > sim.n_temporal_units_to_sim:
-            raise ValueError("Event occurence time + duration is outside simulation, check events and sim json")
-
-        if self.dmg_distrib_regions is None:
-            if not len(self.aff_regions) == 1:
-                raise ValueError("Parameter 'dmg_distrib_across_regions' is None yet there are more than one region affected")
-        elif type(self.dmg_distrib_regions) == str:
-            if self.dmg_distrib_regions !=  "shared":
-                raise ValueError("damage <-> region distribution %s not implemented",self.dmg_distrib_regions)
-        elif type(self.dmg_distrib_regions) == list:
-            if len(self.dmg_distrib_regions) != len(self.aff_regions):
-                raise ValueError("Number of affected regions and size of damage distribution list are not equal")
-            if sum(self.dmg_distrib_regions) != 1.0:
-                warnings.warn("The total distribution of damage across regions is not 1.0")
-        else:
-            raise TypeError("'dmg_distrib_regions' is of type %s, possible types are str or list[float]", type(self.dmg_distrib_regions))
-
-        if self.dmg_distrib_sectors_type != 'gdp':
-            if self.dmg_distrib_sectors is None:
-                if not len(self.aff_sectors) == 1:
-                    raise ValueError("Parameter 'dmg_distrib_across_sectors' is None yet there are more than one sector affected")
-            elif type(self.dmg_distrib_sectors) == str:
-                if self.dmg_distrib_sectors !=  "GDP":
-                    raise ValueError("damage <-> sectors distribution %s not implemented",self.dmg_distrib_sectors)
-            elif type(self.dmg_distrib_sectors) == dict:
-                if not set(self.dmg_distrib_sectors).issubset(sim.model.sectors):
-                    tmp = set(self.dmg_distrib_sectors.keys).difference(set(sim.model.sectors))
-                    raise ValueError("""A least one affected sector is not a valid sector in the mrio table, check events json
-
-            suspicious sectors : {}
-            """.format(tmp))
-            elif type(self.dmg_distrib_sectors) == list:
-                if len(self.dmg_distrib_sectors) != len(self.aff_sectors):
-                    raise ValueError("Number of affected sectors and size of damage distribution list are not equal")
-                if sum(self.dmg_distrib_sectors) != 1.0:
-                    warnings.warn("The total distribution of damage across sectors is not 1.0")
-            else:
-                raise TypeError("'dmg_distrib_sectors' is of type %s, possible types are str or list[float]", type(self.dmg_distrib_sectors))

--- a/boario/extended_models.py
+++ b/boario/extended_models.py
@@ -125,8 +125,8 @@ class ARIOModelPsi(ARIOBaseModel):
 
         """
         #1.
-        production_opt = self.production_cap
-        inventory_constraints = self.inventory_constraints_opt
+        production_opt = self.production_opt.copy()
+        inventory_constraints = self.inventory_constraints_opt.copy()
         # the following line is the same as in the ARIO base class except the multiplication by self.psi
         #2.
         if (stock_constraint := (self.matrix_stock < inventory_constraints) * self.matrix_share_thresh).any():

--- a/boario/utils/misc.py
+++ b/boario/utils/misc.py
@@ -16,19 +16,7 @@
 
 from boario.event import Event
 from collections.abc import Iterable
-
-from json import JSONEncoder
-class EventEncoder(JSONEncoder):
-    def default(self, event:Event):
-        dic = dict(event.__dict__)
-        del dic["final_demand_rebuild"]
-        del dic["final_demand_rebuild_share"]
-        del dic["industry_rebuild"]
-        del dic["industry_rebuild_share"]
-        del dic["production_share_allocated"]
-        del dic["rebuildable"]
-        return dic
-
+import pymrio
 
 def flatten(l):
     for el in l:
@@ -36,3 +24,39 @@ def flatten(l):
             yield from flatten(el)
         else:
             yield el
+
+def lexico_reindex(mrio: pymrio.IOSystem) -> pymrio.IOSystem:
+    """Reindex IOSystem lexicographicaly
+
+    Sort indexes and columns of the dataframe of a ``pymrio`` `IOSystem <https://pymrio.readthedocs.io/en/latest/intro.html>` by
+    lexical order.
+
+    Parameters
+    ----------
+    mrio : pymrio.IOSystem
+        The IOSystem to sort
+
+    Returns
+    -------
+    pymrio.IOSystem
+        The sorted IOSystem
+
+
+    """
+    if mrio.Z is None:
+        raise ValueError("Given mrio has no Z attribute set")
+    mrio.Z = mrio.Z.reindex(sorted(mrio.Z.index), axis=0)
+    mrio.Z = mrio.Z.reindex(sorted(mrio.Z.columns), axis=1)
+    if mrio.Y is None:
+        raise ValueError("Given mrio has no Z attribute set")
+    mrio.Y = mrio.Y.reindex(sorted(mrio.Y.index), axis=0)
+    mrio.Y = mrio.Y.reindex(sorted(mrio.Y.columns), axis=1)
+    if mrio.x is None:
+        raise ValueError("Given mrio has no Z attribute set")
+    mrio.x = mrio.x.reindex(sorted(mrio.x.index), axis=0)
+    if mrio.A is None:
+        raise ValueError("Given mrio has no Z attribute set")
+    mrio.A = mrio.A.reindex(sorted(mrio.A.index), axis=0)
+    mrio.A = mrio.A.reindex(sorted(mrio.A.columns), axis=1)
+
+    return mrio

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -99,27 +99,27 @@ python = [
 ]
 
 [tool.hatch.envs.test]
-python = "3.7"
+python = "3.8"
 
 [tool.pyright]
-include = ["boario"]
+include = ["boario","scripts"]
 exclude = ["**/node_modules",
     "**/__pycache__",
-    "src/"
+    "src/",
+    "api-examples"
 ]
 ignore = ["src/oldstuff"]
 defineConstant = { DEBUG = true }
 stubPath = "boario/stubs"
+pythonPath = "/home/sjuhel/mambaforge-pypy3/envs/boario-dev/bin/python"
+venvPath = "/home/sjuhel/mambaforge-pypy3/envs/boario-dev/"
 
 reportMissingImports = true
 reportMissingTypeStubs = false
 
-pythonVersion = "3.6"
+pythonVersion = "3.8"
 pythonPlatform = "Linux"
 
 executionEnvironments = [
-  { root = "src/web", pythonVersion = "3.5", pythonPlatform = "Windows", extraPaths = [ "src/service_libs" ] },
-  { root = "src/sdk", pythonVersion = "3.0", extraPaths = [ "src/backend" ] },
-  { root = "src/tests", extraPaths = ["src/tests/e2e", "src/sdk" ]},
   { root = "src" }
 ]


### PR DESCRIPTION
This new version (should) close #21 (and resolve #26)

# Changelog :

In depth changes of the `Event` and `Model` class. Switched paradigm from the `Model` holding the per event arrays to each `Event` instances, so it is clearer. 

Also, now the shock is initiated when instantiating an `Event` (and applied at the correct moment afterward), `simulation.py` horrible `shock()` method has disappeared.

Additionally, I changed many attributes to properties, particularly in `Event`, but also in `Model`, because it is way cleaner on many points (readability, value checking, ...).

`Event` class (not instance) now holds several attributes initiated when instantiating a `Model`, such as regions and sectors used. So that, in theory, you may not instantiate an event with regions not in the MRIO used.

`extended_model.py` should show the difference with `base_model.py` more clearly now too.

:warning: Some configuration names have changed again :warning: 

* `dmg_distrib_regions` → `dmg_regional_distrib`
* `dmg_distrib_sectors_type` → `dmg_sectoral_distrib_type`
* `dmg_distrib_sectors` → `dmg_sectoral_distrib`
* `q_dmg` → `kapital_damage`

An additional parameter is required in events json :

* `shock_type` ; which should be set to `"kapital_destroyed_rebuild"` | `"production_capacity_loss"` (WIP not implemented yet)

Additional optional parameter can be set:

* `rebuild_tau` ; which can set a per event custom `rebuild_tau`

Additional (not yet used) placeholder parameters:

* `prod_cap_delta` ; for arbitrary production reduction (no kapital involved)
* `recovery` ; for the type of recovery (This will probably change)

