### PR TITLE
Hot fix for _divide_array_ignore

### DIFF
--- a/boario/utils/misc.py
+++ b/boario/utils/misc.py
@@ -68,7 +68,7 @@ def _fast_sum(array: np.ndarray, axis: int) -> np.ndarray:
 def _divide_arrays_ignore(a, b):
     with np.errstate(divide="ignore", invalid="ignore"):
         ret = np.divide(a, b)
-        np.nan_to_num(ret)
+        np.nan_to_num(ret, copy=False, nan=0.0, posinf=0.0, neginf=0.0)
         return ret
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "boario"
-version = "0.6.0"
+version = "0.6.1"
 description = "BoARIO : The Adaptative Regional Input Output model in python."
 authors = ["Samuel Juhel <pro@sjuhel.org>"]
 license = "GNU General Public License v3 or later (GPLv3+)"

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -20,7 +20,7 @@ def test_divide_arrays_ignore():
     a = np.array([1, 2, 3, 4])
     b = np.array([1, 0, 3, 0])
     result = _divide_arrays_ignore(a, b)
-    expected = np.array([1.0, np.inf, 1.0, np.inf])
+    expected = np.array([1.0, 0.0, 1.0, 0.0])
     assert np.array_equal(result, expected)
 
 


### PR DESCRIPTION
This PR hot fixes an issue with `model.Z_distrib` containing NaNs due to _divide_array_ignore not perfectly implemented.

### PR Author Checklist

- [x] If new release, is version bumped?
- [x] Correct target branch selected (if unsure, select `develop`)
- [x] Descriptive pull request title added
- [x] Source branch up-to-date with target branch
- [x] Documentation updated
- [x] Tests passing
